### PR TITLE
Lock reapp-ui dependency to before it required React 0.14.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-router": "^0.13.2",
     "reapp-object-assign": "^1.0.0",
     "reapp-routes": "^0.10.0",
-    "reapp-ui": "^0.12.54"
+    "reapp-ui": "0.12.55"
   },
   "peerDependencies": {
     "react": "0.13.x"


### PR DESCRIPTION
As seen in https://github.com/reapp/reapp/issues/104

[This reapp-ui commit](https://github.com/reapp/reapp-ui/commit/f014d5575afc269aef4fe2342b9beb97150ba6c6#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L40) bumped the react version to `0.14.x` which breaks reapp. This PR locks reapp-kit to use reapp-ui `0.12.55` (the last working version)

This is a good interim solution until reapp supports 0.14
